### PR TITLE
refactored setup and teardown sample scripts

### DIFF
--- a/bin/terraform/rfsyncprep.cleanup.ksh
+++ b/bin/terraform/rfsyncprep.cleanup.ksh
@@ -3,24 +3,32 @@
 umask 022
 
 outputdir="/tmp"
+
 scriptdir="$( dirname $0 )"
-terraformdir="$( cd $scriptdir ; pwd -P )"
 
+configdir="/tmp/rfslsync_config"
 
-cachedir=$( terraform output -raw recorded_future_cache_dir )
+terraformdir="/tmp/rfslsync_terraform"
 
-varlist=$( cat ${cachedir}/config/rfslconfig.vars )
+cd ${terraformdir}
 
-rm -f $outputdir/rfsyncprep.output.tf
+rm -f ${outputdir}/rfsyncprep.output.tf
 
-terraform apply -auto-approve -destroy ${varlist}
+[ -f ${configdir}/rfslsync.ksh ] && . ${configdir}/rfslsync.ksh
 
-[ -d $terraformdir ] && {
+terraform apply -auto-approve -destroy
 
-    rm -f $terraformdir/terraform.tfstate.backup 
-    rm -f $terraformdir/terraform.tfstate
+[ -d ${terraformdir} ] && {
 
-    rm -f $terraformdir/.terraform.lock.hcl
-    rm -fr $terraformdir/.terraform
+    rm -f ${terraformdir}/terraform.tfstate.backup 
+    rm -f ${terraformdir}/terraform.tfstate
+
+    rm -f ${terraformdir}/*.tf
+    rm -f ${terraformdir}/*.ksh
+    rm -fr ${terraformdir}/.terraform*
+    rm -fr ${terraformdir}/json
 
 }
+
+rm -f ${configdir}/rfslsync.ksh
+rm -f ${configdir}/rfslsync.cfg

--- a/bin/terraform/rfsyncprep.startup.ksh
+++ b/bin/terraform/rfsyncprep.startup.ksh
@@ -3,28 +3,38 @@
 umask 022
 
 outputdir="/tmp"
+
 scriptdir="$( dirname $0 )"
-terraformdir="$( cd $scriptdir ; pwd -P )"
 
-rm -f $terraformdir/terraform.tfstate.backup 
-rm -f $terraformdir/terraform.tfstate
-rm -f $outputdir/rfsyncprep.output.tf
+configdir="/tmp/rfslsync_config"
 
-[ -d $terraformdir/.terraform ] || terraform init
+terraformdir="/tmp/rfslsync_terraform"
 
-terraform plan -out=$outputdir/rfsyncprep.output.tf
-terraform apply -auto-approve $outputdir/rfsyncprep.output.tf
+mkdir -p ${terraformdir}
+mkdir -p ${configdir}
 
-cachedir=$( terraform output -raw recorded_future_cache_dir )
-mkdir -p ${cachedir}/config
+rm -f ${terraformdir}/terraform.tfstate.backup 
+rm -f ${terraformdir}/terraform.tfstate
 
-rm -f ${cachedir}/config/rfslconfig.cfg
-echo "[Default]" >> ${cachedir}/config/rfslconfig.cfg
-terraform output | sed 's/"//g' >> ${cachedir}/config/rfslconfig.cfg
+rm -f ${outputdir}/rfsyncprep.output.tf
 
-cat ${cachedir}/config/rfslconfig.cfg | \
-egrep -i '=' | egrep -i '(sumologic|recorded)_' | sed 's/ //g' | \
-while read pair; 
-do 
-    varlist="-var=\"${pair}\" ${varlist}"; echo ${varlist} > ${cachedir}/config/rfslconfig.vars
-done
+rm -f ${configdir}/rfslsync.ksh
+rm -f ${configdir}/rfslsync.cfg
+
+cp -pr ${scriptdir}/. ${terraformdir}
+
+cd ${terraformdir}
+
+[ -d ${terraformdir}/.terraform ] || terraform init
+
+terraform plan -out=${outputdir}/rfsyncprep.output.tf
+
+terraform apply -auto-approve ${outputdir}/rfsyncprep.output.tf
+
+terraform output -no-color | \
+egrep -i '(sumologic|recorded)' | \
+egrep -vi 'https://' | sed 's/^/export TF_VAR_/g' | \
+sed 's/ = /=/g' > ${configdir}/rfslsync.ksh
+
+echo "[Default]" >> ${configdir}/rfslsync.cfg
+terraform output -no-color | sed 's/"//g' >> ${configdir}/rfslsync.cfg


### PR DESCRIPTION
Only two changes with this pull request.

This creates the local terraform directory, builds the Sumo Logic environment, and creates the configuration file for the scripts
**sumologic-rfsync/bin/terraform/rfsyncprep.startup.ksh**

This tears down the Sumo Logic environment and cleans up the local terraform directory
**sumologic-rfsync/bin/terraform/rfsyncprep.cleanup.ksh**
