### PR TITLE
Close StringIO object to avoid OOM Killer

### DIFF
--- a/bin/scripts/rfsllookups.py
+++ b/bin/scripts/rfsllookups.py
@@ -137,6 +137,7 @@ class RFSLLookups:
             lookupfileid = self.lookup_ids[ioc_type]
             risklist_as_file = StringIO(self.risklists[ioc_type])
             chunks = self.split_csv(risklist_as_file, ioc_type)
+            risklist_as_file.close()
             for idx, chunk in enumerate(chunks):
                 if ARGS.verbose > 4:
                     print(f'Uploading {ioc_type} risklist chunk {idx+1} of {len(chunks)}')


### PR DESCRIPTION
When this script operates without closing the StringIO objects, it is liable to run out of memory during execution because it is holding onto reasonably large StringIO objects from the recorded future CSV files.

Add an explicit close after chunking the file to clean the object out of memory.